### PR TITLE
Check if SDL_main is in use

### DIFF
--- a/colobot-app/src/main.cpp
+++ b/colobot-app/src/main.cpp
@@ -94,10 +94,14 @@ The current layout is the following:
  - src/script - link with the CBot library
 */
 
-//! Entry point to the program
+// On *some* platforms, SDL declares a macro which renames main to SDL_main.
+// If that's the case, use "extern C" to prevent name mangling.
+#ifdef main
 extern "C"
 {
+#endif
 
+//! Entry point to the program
 int main(int argc, char *argv[])
 {
     CLogger logger; // single instance of logger
@@ -176,4 +180,6 @@ int main(int argc, char *argv[])
     return code;
 }
 
+#ifdef main
 } // extern "C"
+#endif


### PR DESCRIPTION
The main() function of colobot-app is declared as extern "C" to prevent name mangling. This is required because on some platforms, SDL2 declares its own main() function and defines a macro that renames the user's main to SDL_main; in which case, name mangling may cause linking failures.

However, when building for platforms where this is not the case, gcc15 complains that specifying linkage for main is not allowed.
> error: cannot declare ‘::main’ with a linkage
>        specification [-Wpedantic]

This commit wraps the extern block in #ifdefs that check if the main -> SDL_main macro is in use.